### PR TITLE
fix: update ESLint config and fix linting errors

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -133,7 +133,7 @@ jobs:
           name: Upload SARIF to GitHub
           command: |
             if [ -f "reports/snyk.sarif" ]; then
-              gh auth login --with-token <<< "$GITHUB_TOKEN"
+              echo "$GITHUB_TOKEN" | gh auth login --with-token
               gh api \
                 --method POST \
                 -H "Accept: application/vnd.github+json" \

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -5,13 +5,15 @@ module.exports = {
   env: {
     browser: true,
     es2020: true,
-    node: true
+    node: true,
+    jest: true
   },
   extends: [
     'eslint:recommended',
     'plugin:@typescript-eslint/recommended',
     'plugin:react-hooks/recommended',
-    'plugin:react/recommended'
+    'plugin:react/recommended',
+    'plugin:jest/recommended'
   ],
   ignorePatterns: ['dist/**/*', '.eslintrc.cjs'],
   parser: '@typescript-eslint/parser',
@@ -23,7 +25,7 @@ module.exports = {
       jsx: true
     }
   },
-  plugins: ['react-refresh', '@typescript-eslint', 'react'],
+  plugins: ['react-refresh', '@typescript-eslint', 'react', 'jest'],
   rules: {
     'react-refresh/only-export-components': [
       'warn',
@@ -31,7 +33,11 @@ module.exports = {
     ],
     'react/react-in-jsx-scope': 'off',
     '@typescript-eslint/no-explicit-any': 'warn',
-    'no-undef': 'off'
+    'no-undef': 'error',
+    '@typescript-eslint/no-unused-vars': ['error', { 
+      argsIgnorePattern: '^_',
+      varsIgnorePattern: '^_'
+    }]
   },
   settings: {
     react: {

--- a/.eslintrc.cjs
+++ b/.eslintrc.cjs
@@ -6,14 +6,14 @@ module.exports = {
     browser: true,
     es2020: true,
     node: true,
-    jest: true
+    jest: true,
   },
   extends: [
     'eslint:recommended',
     'plugin:@typescript-eslint/recommended',
     'plugin:react-hooks/recommended',
     'plugin:react/recommended',
-    'plugin:jest/recommended'
+    'plugin:jest/recommended',
   ],
   ignorePatterns: ['dist/**/*', '.eslintrc.cjs'],
   parser: '@typescript-eslint/parser',
@@ -22,26 +22,26 @@ module.exports = {
     sourceType: 'module',
     project: './tsconfig.json',
     ecmaFeatures: {
-      jsx: true
-    }
+      jsx: true,
+    },
   },
   plugins: ['react-refresh', '@typescript-eslint', 'react', 'jest'],
   rules: {
-    'react-refresh/only-export-components': [
-      'warn',
-      { allowConstantExport: true },
-    ],
+    'react-refresh/only-export-components': ['warn', { allowConstantExport: true }],
     'react/react-in-jsx-scope': 'off',
     '@typescript-eslint/no-explicit-any': 'warn',
     'no-undef': 'error',
-    '@typescript-eslint/no-unused-vars': ['error', { 
-      argsIgnorePattern: '^_',
-      varsIgnorePattern: '^_'
-    }]
+    '@typescript-eslint/no-unused-vars': [
+      'error',
+      {
+        argsIgnorePattern: '^_',
+        varsIgnorePattern: '^_',
+      },
+    ],
   },
   settings: {
     react: {
-      version: 'detect'
-    }
-  }
+      version: 'detect',
+    },
+  },
 }

--- a/src/pages/ProShop.test.tsx
+++ b/src/pages/ProShop.test.tsx
@@ -1,5 +1,5 @@
 import React from 'react'
-import { render, screen, fireEvent } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 import { BrowserRouter } from 'react-router-dom'
 import ProShop from './ProShop'
 

--- a/src/pages/ProShop.test.tsx
+++ b/src/pages/ProShop.test.tsx
@@ -21,7 +21,7 @@ describe('ProShop', () => {
   it('renders all category filter buttons', () => {
     renderProShop()
     expect(screen.getByText('All Products')).toBeInTheDocument()
-    
+
     // Check for categories in the filter buttons
     const filterButtons = screen.getAllByRole('button', { name: /^(Firearms|Accessories|Optics)$/ })
     expect(filterButtons).toHaveLength(3)
@@ -32,20 +32,20 @@ describe('ProShop', () => {
 
   it('renders all products with correct information', () => {
     renderProShop()
-    
+
     // Check for specific products
     expect(screen.getByText('Sim Pistol')).toBeInTheDocument()
     expect(screen.getByText('$499.99')).toBeInTheDocument()
-    
+
     expect(screen.getByText('Premium Ammunition')).toBeInTheDocument()
     expect(screen.getByText('$49.99')).toBeInTheDocument()
-    
+
     expect(screen.getByText('Lodge2A Hat')).toBeInTheDocument()
     expect(screen.getByText('$24.99')).toBeInTheDocument()
-    
+
     expect(screen.getByText('Trijicon Rental')).toBeInTheDocument()
     expect(screen.getByText('$79.99')).toBeInTheDocument()
-    
+
     expect(screen.getByText('Holosun Optic')).toBeInTheDocument()
     expect(screen.getByText('$299.99')).toBeInTheDocument()
   })
@@ -53,7 +53,7 @@ describe('ProShop', () => {
   it('renders product categories correctly', () => {
     renderProShop()
     expect(screen.getByText('All Products')).toBeInTheDocument()
-    
+
     // Check for categories in the filter buttons
     const filterButtons = screen.getAllByRole('button')
     expect(filterButtons.some(button => button.textContent === 'Firearms')).toBe(true)
@@ -72,6 +72,6 @@ describe('ProShop', () => {
     // The shopping cart button is identified by its SVG, so we'll look for its container
     const cartButton = screen.getByRole('button', { name: '' }) // The floating cart button has no text
     expect(cartButton).toBeInTheDocument()
-    expect(cartButton).toHaveClass("p-4 bg-[#333e48] text-white rounded-full")
+    expect(cartButton).toHaveClass('p-4 bg-[#333e48] text-white rounded-full')
   })
 })

--- a/src/pages/ProShop.test.tsx
+++ b/src/pages/ProShop.test.tsx
@@ -72,6 +72,6 @@ describe('ProShop', () => {
     // The shopping cart button is identified by its SVG, so we'll look for its container
     const cartButton = screen.getByRole('button', { name: '' }) // The floating cart button has no text
     expect(cartButton).toBeInTheDocument()
-    expect(cartButton).toHaveClass('p-4 bg-[#333e48] text-white rounded-full')
+    expect(cartButton).toHaveClass("p-4 bg-[#333e48] text-white rounded-full")
   })
 })

--- a/src/pages/Stats.tsx
+++ b/src/pages/Stats.tsx
@@ -7,7 +7,7 @@ import { StatCard } from '../components/ui/StatCard'
 export default function Stats() {
   const [selectedPeriod, setSelectedPeriod] = useState('30')
   const [showAchievementDetails, setShowAchievementDetails] = useState(false)
-  const [selectedAchievement, setSelectedAchievement] = useState(null)
+  const [_selectedAchievement, setSelectedAchievement] = useState(null)
   const [showPeriodDropdown, setShowPeriodDropdown] = useState(false)
 
   const stats = {

--- a/src/pages/Stats.tsx
+++ b/src/pages/Stats.tsx
@@ -163,15 +163,12 @@ export default function Stats() {
         <div className="flex justify-between items-center mb-4">
           <h2 className="text-xl font-semibold text-white">Score Distribution</h2>
           <div className="relative">
-            <Button
-              variant="secondary"
-              onClick={() => setShowPeriodDropdown(!showPeriodDropdown)}
-            >
+            <Button variant="secondary" onClick={() => setShowPeriodDropdown(!showPeriodDropdown)}>
               {`Last ${selectedPeriod} Days`}
             </Button>
             {showPeriodDropdown && (
               <div className="absolute right-0 mt-2 w-48 bg-gray-800 rounded-lg shadow-lg z-10">
-                {['7', '30', '90', 'all'].map((period) => (
+                {['7', '30', '90', 'all'].map(period => (
                   <button
                     key={period}
                     className="block w-full px-4 py-2 text-left text-white hover:bg-gray-700"
@@ -211,9 +208,7 @@ export default function Stats() {
 
       {/* Achievement details modal */}
       {showAchievementDetails && (
-        <div data-testid="achievement-details">
-          {/* Achievement details content */}
-        </div>
+        <div data-testid="achievement-details">{/* Achievement details content */}</div>
       )}
     </div>
   )

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,7 +1,6 @@
 import '@testing-library/jest-dom';
 import { TextEncoder, TextDecoder } from 'util';
 import { configure } from '@testing-library/react';
-import type { Config } from '@jest/types';
 
 // Configure React Testing Library
 configure({

--- a/src/setupTests.ts
+++ b/src/setupTests.ts
@@ -1,65 +1,65 @@
-import '@testing-library/jest-dom';
-import { TextEncoder, TextDecoder } from 'util';
-import { configure } from '@testing-library/react';
+import '@testing-library/jest-dom'
+import { TextEncoder, TextDecoder } from 'util'
+import { configure } from '@testing-library/react'
 
 // Configure React Testing Library
 configure({
   testIdAttribute: 'data-testid',
-});
+})
 
 // Mock IntersectionObserver
 class MockIntersectionObserver {
-  observe = jest.fn();
-  disconnect = jest.fn();
-  unobserve = jest.fn();
+  observe = jest.fn()
+  disconnect = jest.fn()
+  unobserve = jest.fn()
 }
 
 Object.defineProperty(window, 'IntersectionObserver', {
   writable: true,
   configurable: true,
   value: MockIntersectionObserver,
-});
+})
 
 // Mock console methods to suppress React 18 console errors/warnings
-const originalConsoleError = console.error;
-const originalConsoleWarn = console.warn;
+const originalConsoleError = console.error
+const originalConsoleWarn = console.warn
 
 beforeAll(() => {
   console.error = (...args: any[]) => {
-    const message = args.join(' ');
+    const message = args.join(' ')
     if (
       message.includes('ReactDOM.render is no longer supported') ||
       message.includes('Use createRoot instead') ||
       message.includes('StrictMode')
     ) {
-      return;
+      return
     }
-    originalConsoleError.apply(console, args);
-  };
+    originalConsoleError.apply(console, args)
+  }
 
   console.warn = (...args: any[]) => {
-    const message = args.join(' ');
+    const message = args.join(' ')
     if (message.includes('StrictMode')) {
-      return;
+      return
     }
-    originalConsoleWarn.apply(console, args);
-  };
-});
+    originalConsoleWarn.apply(console, args)
+  }
+})
 
 afterAll(() => {
-  console.error = originalConsoleError;
-  console.warn = originalConsoleWarn;
-});
+  console.error = originalConsoleError
+  console.warn = originalConsoleWarn
+})
 
 // Add TextEncoder and TextDecoder to global scope
-Object.assign(global, { TextDecoder, TextEncoder });
+Object.assign(global, { TextDecoder, TextEncoder })
 
 // Add Jest DOM matchers
 declare global {
   namespace jest {
     interface Matchers<R> {
-      toBeInTheDocument(): R;
-      toHaveStyle(style: Record<string, any>): R;
+      toBeInTheDocument(): R
+      toHaveStyle(style: Record<string, any>): R
     }
   }
 }


### PR DESCRIPTION
Fix ESLint errors in test files and configuration to properly handle Jest globals and unused variables.

Changes:
- Added Jest environment and plugin to ESLint config
- Added `eslint-plugin-jest` as a dev dependency
- Fixed unused variable warnings:
  - Prefixed `selectedAchievement` with underscore in Stats.tsx
  - Removed unused `fireEvent` import in ProShop.test.tsx
  - Removed unused `Config` import in setupTests.ts
- Added proper ESLint rules for TypeScript unused variables with patterns for ignored variables

This fixes the following ESLint errors:
- Jest globals not being recognized (`describe`, `it`, `expect`, etc.)
- Unused variables warnings
- Console and global not being recognized in setupTests.ts

Testing:
- [ ] ESLint runs without errors
- [ ] All tests continue to pass
- [ ] No regressions in test functionality