### PR TITLE
fix: add bottom padding to prevent FloatingMenu overlap

### DIFF
--- a/src/pages/Dashboard.tsx
+++ b/src/pages/Dashboard.tsx
@@ -72,7 +72,7 @@ const ActivitiesGrid = (): ReactElement => (
  */
 export default function Dashboard(): ReactElement {
   return (
-    <div className="min-h-screen bg-black">
+    <div className="min-h-screen pb-20 tablet:pb-0">
       <div className="p-6 lg:p-8">
         <DashboardHeader name="John" />
         <StatsGrid />

--- a/src/pages/Events.tsx
+++ b/src/pages/Events.tsx
@@ -1,146 +1,161 @@
-import React from 'react'
-import { Button } from '../components/ui/Button'
-import { Card } from '../components/ui/Card'
-import { Grid } from '../components/layout/Grid'
+import React from "react";
+import { Button } from "../components/ui/Button";
+import { Card } from "../components/ui/Card";
+import { Grid } from "../components/layout/Grid";
 
 interface Event {
-  id: string
-  title: string
-  date: string
-  time: string
-  type: string
-  spots: number
-  status: string
+  id: string;
+  title: string;
+  date: string;
+  time: string;
+  type: string;
+  spots: number;
+  status: string;
 }
 
 export default function Events() {
   const events: Event[] = [
     {
-      id: '1',
-      title: 'Winter Tournament',
-      date: 'Dec 20, 2024',
-      time: '2:00 PM',
-      type: 'Tournament',
+      id: "1",
+      title: "Winter Tournament",
+      date: "Dec 20, 2024",
+      time: "2:00 PM",
+      type: "Tournament",
       spots: 8,
-      status: 'open',
+      status: "open",
     },
     {
-      id: '2',
-      title: 'Pro Training Session',
-      date: 'Dec 22, 2024',
-      time: '10:00 AM',
-      type: 'Training',
+      id: "2",
+      title: "Pro Training Session",
+      date: "Dec 22, 2024",
+      time: "10:00 AM",
+      type: "Training",
       spots: 4,
-      status: 'waitlist',
+      status: "waitlist",
     },
     {
-      id: '3',
-      title: 'Christmas Social',
-      date: 'Dec 24, 2024',
-      time: '1:00 PM',
-      type: 'Social',
+      id: "3",
+      title: "Christmas Social",
+      date: "Dec 24, 2024",
+      time: "1:00 PM",
+      type: "Social",
       spots: 12,
-      status: 'open',
+      status: "open",
     },
-  ]
+  ];
 
   return (
-    <div className="container mx-auto px-4 py-6 md:py-8">
-      <div className="mb-6 md:mb-8">
-        <h1 className="text-2xl md:text-3xl font-bold text-white mb-2">Upcoming Events</h1>
-        <p className="text-gray-400">Register for tournaments and training sessions</p>
-      </div>
+    <div className="min-h-screen pb-20 tablet:pb-0">
+      <div className="container mx-auto px-4 py-6 md:py-8">
+        <div className="mb-6 md:mb-8">
+          <h1 className="text-2xl md:text-3xl font-bold text-white mb-2">
+            Upcoming Events
+          </h1>
+          <p className="text-gray-400">
+            Register for tournaments and training sessions
+          </p>
+        </div>
 
-      {/* Event Categories */}
-      <div className="flex flex-wrap gap-2 mb-6 md:mb-8">
-        <div className="w-full sm:w-auto flex flex-col sm:flex-row gap-2">
-          <Button variant="primary" className="flex-1 sm:flex-none">
-            All Events
-          </Button>
-          <Button variant="secondary" className="flex-1 sm:flex-none">
-            Tournaments
-          </Button>
-          <Button variant="secondary" className="flex-1 sm:flex-none">
-            Training
-          </Button>
-          <Button variant="secondary" className="flex-1 sm:flex-none">
-            Social
+        {/* Event Categories */}
+        <div className="flex flex-wrap gap-2 mb-6 md:mb-8">
+          <div className="w-full sm:w-auto flex flex-col sm:flex-row gap-2">
+            <Button variant="primary" className="flex-1 sm:flex-none">
+              All Events
+            </Button>
+            <Button variant="secondary" className="flex-1 sm:flex-none">
+              Tournaments
+            </Button>
+            <Button variant="secondary" className="flex-1 sm:flex-none">
+              Training
+            </Button>
+            <Button variant="secondary" className="flex-1 sm:flex-none">
+              Social
+            </Button>
+          </div>
+        </div>
+
+        {/* Events Grid */}
+        <Grid cols={1} mdCols={2} lgCols={3} gap={6}>
+          {events.map((event) => (
+            <Card key={event.id} className="flex flex-col p-4 md:p-6">
+              <div className="flex justify-between items-start mb-4">
+                <div>
+                  <h3 className="text-lg md:text-xl font-semibold text-white mb-1">
+                    {event.title}
+                  </h3>
+                  <p className="text-sm text-gray-400">
+                    {event.date} at {event.time}
+                  </p>
+                </div>
+                <span
+                  className={`px-3 py-1 rounded-full text-sm ${
+                    event.type === "Tournament"
+                      ? "bg-blue-100 text-blue-800"
+                      : event.type === "Social"
+                        ? "bg-red-100 text-red-800"
+                        : "bg-purple-100 text-purple-800"
+                  }`}
+                >
+                  {event.type}
+                </span>
+              </div>
+
+              <div className="flex items-center mb-4">
+                <div className="flex items-center space-x-2">
+                  <svg
+                    className="w-5 h-5 text-gray-400"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
+                    />
+                  </svg>
+                  <span className="text-sm text-gray-400">
+                    {event.spots} spots left
+                  </span>
+                </div>
+              </div>
+
+              <div className="mt-auto">
+                {event.status === "open" ? (
+                  <Button variant="primary" className="w-full">
+                    Register Now
+                  </Button>
+                ) : (
+                  <Button variant="secondary" className="w-full">
+                    Waitlist
+                  </Button>
+                )}
+              </div>
+            </Card>
+          ))}
+        </Grid>
+
+        {/* Calendar View Button */}
+        <div className="mt-8 text-center">
+          <Button variant="secondary" className="inline-flex items-center">
+            <svg
+              className="w-5 h-5 mr-2"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+              />
+            </svg>
+            View Calendar
           </Button>
         </div>
       </div>
-
-      {/* Events Grid */}
-      <Grid cols={1} mdCols={2} lgCols={3} gap={6}>
-        {events.map(event => (
-          <Card key={event.id} className="flex flex-col p-4 md:p-6">
-            <div className="flex justify-between items-start mb-4">
-              <div>
-                <h3 className="text-lg md:text-xl font-semibold text-white mb-1">{event.title}</h3>
-                <p className="text-sm text-gray-400">
-                  {event.date} at {event.time}
-                </p>
-              </div>
-              <span
-                className={`px-3 py-1 rounded-full text-sm ${
-                  event.type === 'Tournament'
-                    ? 'bg-blue-100 text-blue-800'
-                    : event.type === 'Social'
-                      ? 'bg-red-100 text-red-800'
-                      : 'bg-purple-100 text-purple-800'
-                }`}
-              >
-                {event.type}
-              </span>
-            </div>
-
-            <div className="flex items-center mb-4">
-              <div className="flex items-center space-x-2">
-                <svg
-                  className="w-5 h-5 text-gray-400"
-                  fill="none"
-                  stroke="currentColor"
-                  viewBox="0 0 24 24"
-                >
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M17 20h5v-2a3 3 0 00-5.356-1.857M17 20H7m10 0v-2c0-.656-.126-1.283-.356-1.857M7 20H2v-2a3 3 0 015.356-1.857M7 20v-2c0-.656.126-1.283.356-1.857m0 0a5.002 5.002 0 019.288 0M15 7a3 3 0 11-6 0 3 3 0 016 0zm6 3a2 2 0 11-4 0 2 2 0 014 0zM7 10a2 2 0 11-4 0 2 2 0 014 0z"
-                  />
-                </svg>
-                <span className="text-sm text-gray-400">{event.spots} spots left</span>
-              </div>
-            </div>
-
-            <div className="mt-auto">
-              {event.status === 'open' ? (
-                <Button variant="primary" className="w-full">
-                  Register Now
-                </Button>
-              ) : (
-                <Button variant="secondary" className="w-full">
-                  Waitlist
-                </Button>
-              )}
-            </div>
-          </Card>
-        ))}
-      </Grid>
-
-      {/* Calendar View Button */}
-      <div className="mt-8 text-center">
-        <Button variant="secondary" className="inline-flex items-center">
-          <svg className="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
-            />
-          </svg>
-          View Calendar
-        </Button>
-      </div>
     </div>
-  )
+  );
 }

--- a/src/pages/ProShop.tsx
+++ b/src/pages/ProShop.tsx
@@ -1,131 +1,154 @@
-import React from 'react'
+import React from "react";
 
 interface Product {
-  id: string
-  name: string
-  price: number
-  image: string
-  category: string
+  id: string;
+  name: string;
+  price: number;
+  image: string;
+  category: string;
 }
 
 export default function ProShop() {
   const products: Product[] = [
     {
-      id: '1',
-      name: 'Sim Pistol',
+      id: "1",
+      name: "Sim Pistol",
       price: 499.99,
-      image: 'driver.jpg',
-      category: 'Firearms',
+      image: "driver.jpg",
+      category: "Firearms",
     },
     {
-      id: '2',
-      name: 'Premium Ammunition',
+      id: "2",
+      name: "Premium Ammunition",
       price: 49.99,
-      image: 'balls.jpg',
-      category: 'Accessories',
+      image: "balls.jpg",
+      category: "Accessories",
     },
     {
-      id: '3',
-      name: 'Lodge2A Hat',
+      id: "3",
+      name: "Lodge2A Hat",
       price: 24.99,
-      image: 'glove.jpg',
-      category: 'Accessories',
+      image: "glove.jpg",
+      category: "Accessories",
     },
     {
-      id: '4',
-      name: 'Trijicon Rental',
+      id: "4",
+      name: "Trijicon Rental",
       price: 79.99,
-      image: 'polo.jpg',
-      category: 'Optics',
+      image: "polo.jpg",
+      category: "Optics",
     },
     {
-      id: '6',
-      name: 'Holosun Optic',
+      id: "6",
+      name: "Holosun Optic",
       price: 299.99,
-      image: 'wedges.jpg',
-      category: 'Optics',
+      image: "wedges.jpg",
+      category: "Optics",
     },
-  ]
+  ];
 
   return (
-    <div className="container mx-auto px-4 py-6 md:py-8">
-      <div className="mb-6 md:mb-8">
-        <h1 className="text-2xl md:text-3xl font-bold text-white mb-2">Pro Shop</h1>
-        <p className="text-gray-400">Browse our collection of premium equipment</p>
-      </div>
+    <div className="min-h-screen pb-20 tablet:pb-0">
+      <div className="container mx-auto px-4 py-6 md:py-8">
+        <div className="mb-6 md:mb-8">
+          <h1 className="text-2xl md:text-3xl font-bold text-white mb-2">
+            Pro Shop
+          </h1>
+          <p className="text-gray-400">
+            Browse our collection of premium equipment
+          </p>
+        </div>
 
-      {/* Categories */}
-      <div className="flex flex-wrap gap-2 mb-6 md:mb-8">
-        <button className="px-4 py-2 bg-[#333e48] text-white rounded-lg hover:bg-[#4a5761] transition-colors">
-          All Products
-        </button>
-        <button className="px-4 py-2 bg-dark-200 text-gray-400 rounded-lg hover:bg-[#4a5761] hover:text-white transition-colors">
-          Firearms
-        </button>
-        <button className="px-4 py-2 bg-dark-200 text-gray-400 rounded-lg hover:bg-[#4a5761] hover:text-white transition-colors">
-          Accessories
-        </button>
-        <button className="px-4 py-2 bg-dark-200 text-gray-400 rounded-lg hover:bg-[#4a5761] hover:text-white transition-colors">
-          Optics
-        </button>
-      </div>
+        {/* Categories */}
+        <div className="flex flex-wrap gap-2 mb-6 md:mb-8">
+          <button className="px-4 py-2 bg-[#333e48] text-white rounded-lg hover:bg-[#4a5761] transition-colors">
+            All Products
+          </button>
+          <button className="px-4 py-2 bg-dark-200 text-gray-400 rounded-lg hover:bg-[#4a5761] hover:text-white transition-colors">
+            Firearms
+          </button>
+          <button className="px-4 py-2 bg-dark-200 text-gray-400 rounded-lg hover:bg-[#4a5761] hover:text-white transition-colors">
+            Accessories
+          </button>
+          <button className="px-4 py-2 bg-dark-200 text-gray-400 rounded-lg hover:bg-[#4a5761] hover:text-white transition-colors">
+            Optics
+          </button>
+        </div>
 
-      {/* Products Grid */}
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
-        {products.map(product => (
-          <div key={product.id} className="bg-dark-100 rounded-xl overflow-hidden">
-            <div className="h-48 bg-dark-200 flex items-center justify-center">
-              <svg
-                className="w-12 h-12 text-gray-400"
-                fill="none"
-                stroke="currentColor"
-                viewBox="0 0 24 24"
-              >
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
-                />
-              </svg>
-            </div>
-            <div className="p-4">
-              <div className="flex justify-between items-start mb-2">
-                <div>
-                  <h3 className="text-lg font-semibold text-white">{product.name}</h3>
-                  <p className="text-sm text-gray-400">{product.category}</p>
-                </div>
-                <span className="text-lg font-bold text-white">${product.price}</span>
-              </div>
-              <button className="w-full mt-4 py-2 px-4 bg-[#333e48] text-white rounded-lg hover:bg-[#4a5761] transition-colors flex items-center justify-center">
-                <svg className="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
+        {/* Products Grid */}
+        <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-3 gap-6">
+          {products.map((product) => (
+            <div
+              key={product.id}
+              className="bg-dark-100 rounded-xl overflow-hidden"
+            >
+              <div className="h-48 bg-dark-200 flex items-center justify-center">
+                <svg
+                  className="w-12 h-12 text-gray-400"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
                   <path
                     strokeLinecap="round"
                     strokeLinejoin="round"
                     strokeWidth={2}
-                    d="M3 3h2l.4 2M7 13h10l4-8H5.4M7 13L5.4 5M7 13l-2.293 2.293c-.63.63-.184 1.707.707 1.707H17m0 0a2 2 0 100 4 2 2 0 000-4zm-8 2a2 2 0 11-4 0 2 2 0 014 0z"
+                    d="M4 16l4.586-4.586a2 2 0 012.828 0L16 16m-2-2l1.586-1.586a2 2 0 012.828 0L20 14m-6-6h.01M6 20h12a2 2 0 002-2V6a2 2 0 00-2-2H6a2 2 0 00-2 2v12a2 2 0 002 2z"
                   />
                 </svg>
-                Add to Cart
-              </button>
+              </div>
+              <div className="p-4">
+                <div className="flex justify-between items-start mb-2">
+                  <div>
+                    <h3 className="text-lg font-semibold text-white">
+                      {product.name}
+                    </h3>
+                    <p className="text-sm text-gray-400">{product.category}</p>
+                  </div>
+                  <span className="text-lg font-bold text-white">
+                    ${product.price}
+                  </span>
+                </div>
+                <button className="w-full mt-4 py-2 px-4 bg-[#333e48] text-white rounded-lg hover:bg-[#4a5761] transition-colors flex items-center justify-center">
+                  <svg
+                    className="w-5 h-5 mr-2"
+                    fill="none"
+                    stroke="currentColor"
+                    viewBox="0 0 24 24"
+                  >
+                    <path
+                      strokeLinecap="round"
+                      strokeLinejoin="round"
+                      strokeWidth={2}
+                      d="M3 3h2l.4 2M7 13h10l4-8H5.4M7 13L5.4 5M7 13l-2.293 2.293c-.63.63-.184 1.707.707 1.707H17m0 0a2 2 0 100 4 2 2 0 000-4zm-8 2a2 2 0 11-4 0 2 2 0 014 0z"
+                    />
+                  </svg>
+                  Add to Cart
+                </button>
+              </div>
             </div>
-          </div>
-        ))}
-      </div>
+          ))}
+        </div>
 
-      {/* Shopping Cart Preview */}
-      <div className="fixed bottom-6 right-6">
-        <button className="p-4 bg-[#333e48] text-white rounded-full shadow-lg hover:bg-[#4a5761] transition-colors">
-          <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-            <path
-              strokeLinecap="round"
-              strokeLinejoin="round"
-              strokeWidth={2}
-              d="M3 3h2l.4 2M7 13h10l4-8H5.4M7 13L5.4 5M7 13l-2.293 2.293c-.63.63-.184 1.707.707 1.707H17m0 0a2 2 0 100 4 2 2 0 000-4zm-8 2a2 2 0 11-4 0 2 2 0 014 0z"
-            />
-          </svg>
-        </button>
+        {/* Shopping Cart Preview */}
+        <div className="fixed bottom-6 right-6">
+          <button className="p-4 bg-[#333e48] text-white rounded-full shadow-lg hover:bg-[#4a5761] transition-colors">
+            <svg
+              className="w-6 h-6"
+              fill="none"
+              stroke="currentColor"
+              viewBox="0 0 24 24"
+            >
+              <path
+                strokeLinecap="round"
+                strokeLinejoin="round"
+                strokeWidth={2}
+                d="M3 3h2l.4 2M7 13h10l4-8H5.4M7 13L5.4 5M7 13l-2.293 2.293c-.63.63-.184 1.707.707 1.707H17m0 0a2 2 0 100 4 2 2 0 000-4zm-8 2a2 2 0 11-4 0 2 2 0 014 0z"
+              />
+            </svg>
+          </button>
+        </div>
       </div>
     </div>
-  )
+  );
 }

--- a/src/pages/Reservations.tsx
+++ b/src/pages/Reservations.tsx
@@ -1,128 +1,166 @@
-import React, { useState } from 'react'
-import { Button } from '../components/ui/Button'
-import { BayIcon, TableIcon } from '../components/icons'
+import React, { useState } from "react";
+import { Button } from "../components/ui/Button";
+import { BayIcon, TableIcon } from "../components/icons";
 
 interface TimeSlot {
-  id: string
-  time: string
-  available: boolean
+  id: string;
+  time: string;
+  available: boolean;
 }
 
 export default function Reservations() {
-  const [guestCount, setGuestCount] = useState(1)
+  const [guestCount, setGuestCount] = useState(1);
   const timeSlots: TimeSlot[] = [
-    { id: '1', time: '9:00 AM', available: true },
-    { id: '2', time: '10:00 AM', available: false },
-    { id: '3', time: '11:00 AM', available: true },
-    { id: '4', time: '12:00 PM', available: true },
-    { id: '5', time: '1:00 PM', available: false },
-    { id: '6', time: '2:00 PM', available: true },
-  ]
+    { id: "1", time: "9:00 AM", available: true },
+    { id: "2", time: "10:00 AM", available: false },
+    { id: "3", time: "11:00 AM", available: true },
+    { id: "4", time: "12:00 PM", available: true },
+    { id: "5", time: "1:00 PM", available: false },
+    { id: "6", time: "2:00 PM", available: true },
+  ];
 
   return (
-    <div className="container mx-auto px-4 py-6 md:py-8">
-      <div className="mb-6 md:mb-8">
-        <h1 className="text-2xl md:text-3xl font-bold text-white mb-2">Make a Reservation</h1>
-        <p className="text-gray-400">Book your bay or table</p>
-      </div>
+    <div className="min-h-screen pb-20 tablet:pb-0">
+      <div className="container mx-auto px-4 py-6 md:py-8">
+        <div className="mb-6 md:mb-8">
+          <h1 className="text-2xl md:text-3xl font-bold text-white mb-2">
+            Make a Reservation
+          </h1>
+          <p className="text-gray-400">Book your bay or table</p>
+        </div>
 
-      {/* Reservation Type Selection */}
-      <div className="grid grid-cols-1 gap-4 mb-6 md:mb-8">
-        <Button variant="primary" icon={<BayIcon />} fullWidth>
-          Bay Reservation
-        </Button>
-        <Button variant="secondary" icon={<TableIcon />} fullWidth>
-          Table Reservation
-        </Button>
-      </div>
+        {/* Reservation Type Selection */}
+        <div className="grid grid-cols-1 gap-4 mb-6 md:mb-8">
+          <Button variant="primary" icon={<BayIcon />} fullWidth>
+            Bay Reservation
+          </Button>
+          <Button variant="secondary" icon={<TableIcon />} fullWidth>
+            Table Reservation
+          </Button>
+        </div>
 
-      {/* Date Selection */}
-      <div className="bg-[#1e2327] rounded-xl p-4 md:p-6 mb-6 md:mb-8">
-        <h2 className="text-lg md:text-xl font-semibold text-white mb-4">Select Date</h2>
-        <div className="grid grid-cols-3 md:grid-cols-7 gap-2">
-          {Array.from({ length: 7 }).map((_, index) => {
-            const date = new Date()
-            date.setDate(date.getDate() + index)
-            return (
-              <Button key={index} variant={index === 0 ? 'primary' : 'secondary'} fullWidth>
-                <div className="flex flex-col items-center space-y-1">
-                  <div className="text-sm font-medium">
-                    {date.toLocaleDateString('en-US', { weekday: 'short' })}
+        {/* Date Selection */}
+        <div className="bg-[#1e2327] rounded-xl p-4 md:p-6 mb-6 md:mb-8">
+          <h2 className="text-lg md:text-xl font-semibold text-white mb-4">
+            Select Date
+          </h2>
+          <div className="grid grid-cols-3 md:grid-cols-7 gap-2">
+            {Array.from({ length: 7 }).map((_, index) => {
+              const date = new Date();
+              date.setDate(date.getDate() + index);
+              return (
+                <Button
+                  key={index}
+                  variant={index === 0 ? "primary" : "secondary"}
+                  fullWidth
+                >
+                  <div className="flex flex-col items-center space-y-1">
+                    <div className="text-sm font-medium">
+                      {date.toLocaleDateString("en-US", { weekday: "short" })}
+                    </div>
+                    <div className="text-lg font-bold">{date.getDate()}</div>
                   </div>
-                  <div className="text-lg font-bold">{date.getDate()}</div>
-                </div>
+                </Button>
+              );
+            })}
+          </div>
+        </div>
+
+        {/* Time Selection */}
+        <div className="bg-[#1e2327] rounded-xl p-4 md:p-6 mb-6 md:mb-8">
+          <h2 className="text-lg md:text-xl font-semibold text-white mb-4">
+            Select Time
+          </h2>
+          <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-2 gap-3">
+            {timeSlots.map((slot) => (
+              <Button
+                key={slot.id}
+                variant={slot.available ? "primary" : "secondary"}
+                disabled={!slot.available}
+                fullWidth
+              >
+                {slot.time}
               </Button>
-            )
-          })}
+            ))}
+          </div>
         </div>
-      </div>
 
-      {/* Time Selection */}
-      <div className="bg-[#1e2327] rounded-xl p-4 md:p-6 mb-6 md:mb-8">
-        <h2 className="text-lg md:text-xl font-semibold text-white mb-4">Select Time</h2>
-        <div className="grid grid-cols-2 md:grid-cols-3 lg:grid-cols-2 gap-3">
-          {timeSlots.map(slot => (
+        {/* Guest Count */}
+        <div className="bg-[#1e2327] rounded-xl p-4 md:p-6 mb-6 md:mb-8">
+          <h2 className="text-lg md:text-xl font-semibold text-white mb-4">
+            Number of Guests
+          </h2>
+          <div className="flex items-center space-x-4">
             <Button
-              key={slot.id}
-              variant={slot.available ? 'primary' : 'secondary'}
-              disabled={!slot.available}
-              fullWidth
+              variant="secondary"
+              onClick={() => setGuestCount((prev) => Math.max(1, prev - 1))}
+              disabled={guestCount <= 1}
+              aria-label="Decrease guest count"
+              icon={
+                <svg
+                  className="w-6 h-6"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M20 12H4"
+                  />
+                </svg>
+              }
+            />
+            <span
+              className="text-xl font-bold text-white"
+              aria-label="Guest count"
+              role="status"
             >
-              {slot.time}
-            </Button>
-          ))}
+              {guestCount}
+            </span>
+            <Button
+              variant="secondary"
+              onClick={() => setGuestCount((prev) => Math.min(8, prev + 1))}
+              disabled={guestCount >= 8}
+              aria-label="Increase guest count"
+              icon={
+                <svg
+                  className="w-6 h-6"
+                  fill="none"
+                  stroke="currentColor"
+                  viewBox="0 0 24 24"
+                >
+                  <path
+                    strokeLinecap="round"
+                    strokeLinejoin="round"
+                    strokeWidth={2}
+                    d="M12 4v16m8-8H4"
+                  />
+                </svg>
+              }
+            />
+          </div>
         </div>
-      </div>
 
-      {/* Guest Count */}
-      <div className="bg-[#1e2327] rounded-xl p-4 md:p-6 mb-6 md:mb-8">
-        <h2 className="text-lg md:text-xl font-semibold text-white mb-4">Number of Guests</h2>
-        <div className="flex items-center space-x-4">
-          <Button
-            variant="secondary"
-            onClick={() => setGuestCount(prev => Math.max(1, prev - 1))}
-            disabled={guestCount <= 1}
-            aria-label="Decrease guest count"
-            icon={
-              <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path strokeLinecap="round" strokeLinejoin="round" strokeWidth={2} d="M20 12H4" />
-              </svg>
-            }
-          />
-          <span className="text-xl font-bold text-white" aria-label="Guest count" role="status">
-            {guestCount}
-          </span>
-          <Button
-            variant="secondary"
-            onClick={() => setGuestCount(prev => Math.min(8, prev + 1))}
-            disabled={guestCount >= 8}
-            aria-label="Increase guest count"
-            icon={
-              <svg className="w-6 h-6" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                <path
-                  strokeLinecap="round"
-                  strokeLinejoin="round"
-                  strokeWidth={2}
-                  d="M12 4v16m8-8H4"
-                />
-              </svg>
-            }
-          />
-        </div>
+        {/* Submit Button */}
+        <Button variant="primary" fullWidth>
+          <svg
+            className="w-5 h-5 mr-2"
+            fill="none"
+            stroke="currentColor"
+            viewBox="0 0 24 24"
+          >
+            <path
+              strokeLinecap="round"
+              strokeLinejoin="round"
+              strokeWidth={2}
+              d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
+            />
+          </svg>
+          Complete Reservation
+        </Button>
       </div>
-
-      {/* Submit Button */}
-      <Button variant="primary" fullWidth>
-        <svg className="w-5 h-5 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-          <path
-            strokeLinecap="round"
-            strokeLinejoin="round"
-            strokeWidth={2}
-            d="M8 7V3m8 4V3m-9 8h10M5 21h14a2 2 0 002-2V7a2 2 0 00-2-2H5a2 2 0 00-2 2v12a2 2 0 002 2z"
-          />
-        </svg>
-        Complete Reservation
-      </Button>
     </div>
-  )
+  );
 }

--- a/src/pages/Settings.tsx
+++ b/src/pages/Settings.tsx
@@ -1,126 +1,79 @@
-import React from 'react'
+import React from "react";
 
 interface PaymentHistory {
-  id: string
-  date: string
-  description: string
-  amount: number
-  status: 'completed' | 'pending' | 'failed'
+  id: string;
+  date: string;
+  description: string;
+  amount: number;
+  status: "completed" | "pending" | "failed";
 }
 
 export default function Settings() {
   const paymentHistory: PaymentHistory[] = [
     {
-      id: '1',
-      date: 'Dec 15, 2024',
-      description: 'Bay Reservation - 2 Hours',
+      id: "1",
+      date: "Dec 15, 2024",
+      description: "Bay Reservation - 2 Hours",
       amount: 120.0,
-      status: 'completed',
+      status: "completed",
     },
     {
-      id: '2',
-      date: 'Dec 10, 2024',
-      description: 'Pro Shop Purchase - Golf Balls',
+      id: "2",
+      date: "Dec 10, 2024",
+      description: "Pro Shop Purchase - Golf Balls",
       amount: 45.99,
-      status: 'completed',
+      status: "completed",
     },
     {
-      id: '3',
-      date: 'Dec 5, 2024',
-      description: 'Monthly Membership Fee',
+      id: "3",
+      date: "Dec 5, 2024",
+      description: "Monthly Membership Fee",
       amount: 199.99,
-      status: 'completed',
+      status: "completed",
     },
     {
-      id: '4',
-      date: 'Nov 28, 2024',
-      description: 'Table Reservation - Dinner',
+      id: "4",
+      date: "Nov 28, 2024",
+      description: "Table Reservation - Dinner",
       amount: 85.0,
-      status: 'completed',
+      status: "completed",
     },
-  ]
+  ];
 
-  const getStatusColor = (status: PaymentHistory['status']) => {
+  const getStatusColor = (status: PaymentHistory["status"]) => {
     switch (status) {
-      case 'completed':
-        return 'bg-green-100 text-green-800'
-      case 'pending':
-        return 'bg-yellow-100 text-yellow-800'
-      case 'failed':
-        return 'bg-red-100 text-red-800'
+      case "completed":
+        return "bg-green-100 text-green-800";
+      case "pending":
+        return "bg-yellow-100 text-yellow-800";
+      case "failed":
+        return "bg-red-100 text-red-800";
       default:
-        return 'bg-gray-100 text-gray-800'
+        return "bg-gray-100 text-gray-800";
     }
-  }
+  };
 
   return (
-    <div className="tablet:pl-16 tablet:group-hover:pl-64 transition-[padding] duration-200">
-      <div className="max-w-[1200px] mx-auto px-4 py-6 md:py-8">
-        <h1 className="text-2xl md:text-3xl font-bold text-white mb-6">Settings</h1>
+    <div className="min-h-screen pb-20 tablet:pb-0">
+      <div className="tablet:pl-16 tablet:group-hover:pl-64 transition-[padding] duration-200">
+        <div className="max-w-[1200px] mx-auto px-4 py-6 md:py-8">
+          <h1 className="text-2xl md:text-3xl font-bold text-white mb-6">
+            Settings
+          </h1>
 
-        {/* Sections Grid */}
-        <div className="grid gap-6 pb-8">
-          {/* Personal Information */}
-          <section className="bg-dark-100 rounded-xl p-6">
-            <div className="flex flex-col md:flex-row justify-between items-start md:items-center mb-6">
-              <div className="mb-4 md:mb-0">
-                <h2 className="text-xl font-semibold text-white">Personal Information</h2>
-                <p className="text-sm text-gray-400">Update your personal details</p>
-              </div>
-              <button className="w-full md:w-auto px-4 py-2 bg-[#333e48] text-white rounded-lg hover:bg-[#4a5761] transition-colors flex items-center justify-center">
-                <svg className="w-4 h-4 mr-2" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-                  <path
-                    strokeLinecap="round"
-                    strokeLinejoin="round"
-                    strokeWidth={2}
-                    d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z"
-                  />
-                </svg>
-                Edit Profile
-              </button>
-            </div>
-
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-              <div>
-                <label className="block text-sm font-medium text-gray-400 mb-1">Email</label>
-                <div className="text-white">john.rambo@badass.com</div>
-              </div>
-
-              <div>
-                <label className="block text-sm font-medium text-gray-400 mb-1">Phone</label>
-                <div className="text-white">+1 (555) 123-4567</div>
-              </div>
-
-              <div>
-                <label className="block text-sm font-medium text-gray-400 mb-1">Address</label>
-                <div className="text-white">123 Main Street</div>
-              </div>
-
-              <div>
-                <label className="block text-sm font-medium text-gray-400 mb-1">City</label>
-                <div className="text-white">Hope</div>
-              </div>
-
-              <div>
-                <label className="block text-sm font-medium text-gray-400 mb-1">State</label>
-                <div className="text-white">WA</div>
-              </div>
-
-              <div>
-                <label className="block text-sm font-medium text-gray-400 mb-1">Zip</label>
-                <div className="text-white">98826</div>
-              </div>
-            </div>
-          </section>
-
-          {/* Payment History */}
-          <section className="bg-dark-100 rounded-xl p-6">
-            <div className="flex flex-col md:flex-row justify-between items-start md:items-center mb-6">
-              <div className="mb-4 md:mb-0">
-                <h2 className="text-xl font-semibold text-white">Payment History</h2>
-                <p className="text-sm text-gray-400">View and manage your billing information</p>
-              </div>
-              <div className="flex flex-col md:flex-row w-full md:w-auto space-y-3 md:space-y-0 md:space-x-3">
+          {/* Sections Grid */}
+          <div className="grid gap-6 pb-8">
+            {/* Personal Information */}
+            <section className="bg-dark-100 rounded-xl p-6">
+              <div className="flex flex-col md:flex-row justify-between items-start md:items-center mb-6">
+                <div className="mb-4 md:mb-0">
+                  <h2 className="text-xl font-semibold text-white">
+                    Personal Information
+                  </h2>
+                  <p className="text-sm text-gray-400">
+                    Update your personal details
+                  </p>
+                </div>
                 <button className="w-full md:w-auto px-4 py-2 bg-[#333e48] text-white rounded-lg hover:bg-[#4a5761] transition-colors flex items-center justify-center">
                   <svg
                     className="w-4 h-4 mr-2"
@@ -132,138 +85,247 @@ export default function Settings() {
                       strokeLinecap="round"
                       strokeLinejoin="round"
                       strokeWidth={2}
-                      d="M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z"
+                      d="M15.232 5.232l3.536 3.536m-2.036-5.036a2.5 2.5 0 113.536 3.536L6.5 21.036H3v-3.572L16.732 3.732z"
                     />
                   </svg>
-                  Edit Billing
-                </button>
-                <button className="w-full md:w-auto px-4 py-2 bg-[#333e48] text-white rounded-lg hover:bg-[#4a5761] transition-colors">
-                  View All
+                  Edit Profile
                 </button>
               </div>
-            </div>
 
-            <div className="space-y-4">
-              {paymentHistory.map(payment => (
-                <div
-                  key={payment.id}
-                  className="flex flex-col md:flex-row items-start md:items-center justify-between p-4 bg-dark-200 rounded-lg"
-                >
-                  <div className="mb-3 md:mb-0">
-                    <h3 className="font-medium text-white">{payment.description}</h3>
-                    <p className="text-sm text-gray-400">{payment.date}</p>
-                  </div>
-                  <div className="flex flex-col md:flex-row items-start md:items-center space-y-2 md:space-y-0 md:space-x-4">
-                    <span className="text-lg font-medium text-white">
-                      ${payment.amount.toFixed(2)}
-                    </span>
-                    <span
-                      className={`px-3 py-1 rounded-full text-sm ${getStatusColor(payment.status)}`}
+              <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
+                <div>
+                  <label className="block text-sm font-medium text-gray-400 mb-1">
+                    Email
+                  </label>
+                  <div className="text-white">john.rambo@badass.com</div>
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-gray-400 mb-1">
+                    Phone
+                  </label>
+                  <div className="text-white">+1 (555) 123-4567</div>
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-gray-400 mb-1">
+                    Address
+                  </label>
+                  <div className="text-white">123 Main Street</div>
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-gray-400 mb-1">
+                    City
+                  </label>
+                  <div className="text-white">Hope</div>
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-gray-400 mb-1">
+                    State
+                  </label>
+                  <div className="text-white">WA</div>
+                </div>
+
+                <div>
+                  <label className="block text-sm font-medium text-gray-400 mb-1">
+                    Zip
+                  </label>
+                  <div className="text-white">98826</div>
+                </div>
+              </div>
+            </section>
+
+            {/* Payment History */}
+            <section className="bg-dark-100 rounded-xl p-6">
+              <div className="flex flex-col md:flex-row justify-between items-start md:items-center mb-6">
+                <div className="mb-4 md:mb-0">
+                  <h2 className="text-xl font-semibold text-white">
+                    Payment History
+                  </h2>
+                  <p className="text-sm text-gray-400">
+                    View and manage your billing information
+                  </p>
+                </div>
+                <div className="flex flex-col md:flex-row w-full md:w-auto space-y-3 md:space-y-0 md:space-x-3">
+                  <button className="w-full md:w-auto px-4 py-2 bg-[#333e48] text-white rounded-lg hover:bg-[#4a5761] transition-colors flex items-center justify-center">
+                    <svg
+                      className="w-4 h-4 mr-2"
+                      fill="none"
+                      stroke="currentColor"
+                      viewBox="0 0 24 24"
                     >
-                      {payment.status.charAt(0).toUpperCase() + payment.status.slice(1)}
-                    </span>
+                      <path
+                        strokeLinecap="round"
+                        strokeLinejoin="round"
+                        strokeWidth={2}
+                        d="M3 10h18M7 15h1m4 0h1m-7 4h12a3 3 0 003-3V8a3 3 0 00-3-3H6a3 3 0 00-3 3v8a3 3 0 003 3z"
+                      />
+                    </svg>
+                    Edit Billing
+                  </button>
+                  <button className="w-full md:w-auto px-4 py-2 bg-[#333e48] text-white rounded-lg hover:bg-[#4a5761] transition-colors">
+                    View All
+                  </button>
+                </div>
+              </div>
+
+              <div className="space-y-4">
+                {paymentHistory.map((payment) => (
+                  <div
+                    key={payment.id}
+                    className="flex flex-col md:flex-row items-start md:items-center justify-between p-4 bg-dark-200 rounded-lg"
+                  >
+                    <div className="mb-3 md:mb-0">
+                      <h3 className="font-medium text-white">
+                        {payment.description}
+                      </h3>
+                      <p className="text-sm text-gray-400">{payment.date}</p>
+                    </div>
+                    <div className="flex flex-col md:flex-row items-start md:items-center space-y-2 md:space-y-0 md:space-x-4">
+                      <span className="text-lg font-medium text-white">
+                        ${payment.amount.toFixed(2)}
+                      </span>
+                      <span
+                        className={`px-3 py-1 rounded-full text-sm ${getStatusColor(payment.status)}`}
+                      >
+                        {payment.status.charAt(0).toUpperCase() +
+                          payment.status.slice(1)}
+                      </span>
+                    </div>
                   </div>
-                </div>
-              ))}
-            </div>
-          </section>
+                ))}
+              </div>
+            </section>
 
-          {/* Notifications */}
-          <section className="bg-dark-100 rounded-xl p-6">
-            <h2 className="text-xl font-semibold text-white mb-4">Notifications</h2>
-            <div className="space-y-4">
-              <div className="flex items-center justify-between">
-                <div>
-                  <h3 className="text-white font-medium">Email Notifications</h3>
-                  <p className="text-sm text-gray-400">Receive updates about your reservations</p>
+            {/* Notifications */}
+            <section className="bg-dark-100 rounded-xl p-6">
+              <h2 className="text-xl font-semibold text-white mb-4">
+                Notifications
+              </h2>
+              <div className="space-y-4">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <h3 className="text-white font-medium">
+                      Email Notifications
+                    </h3>
+                    <p className="text-sm text-gray-400">
+                      Receive updates about your reservations
+                    </p>
+                  </div>
+                  <label className="relative inline-flex items-center cursor-pointer">
+                    <input
+                      type="checkbox"
+                      className="sr-only peer"
+                      defaultChecked
+                    />
+                    <div className="w-11 h-6 bg-gray-600 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-[#333e48]"></div>
+                  </label>
                 </div>
-                <label className="relative inline-flex items-center cursor-pointer">
-                  <input type="checkbox" className="sr-only peer" defaultChecked />
-                  <div className="w-11 h-6 bg-gray-600 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-[#333e48]"></div>
-                </label>
-              </div>
-              <div className="flex items-center justify-between">
-                <div>
-                  <h3 className="text-white font-medium">Push Notifications</h3>
-                  <p className="text-sm text-gray-400">Get alerts on your mobile device</p>
+                <div className="flex items-center justify-between">
+                  <div>
+                    <h3 className="text-white font-medium">
+                      Push Notifications
+                    </h3>
+                    <p className="text-sm text-gray-400">
+                      Get alerts on your mobile device
+                    </p>
+                  </div>
+                  <label className="relative inline-flex items-center cursor-pointer">
+                    <input type="checkbox" className="sr-only peer" />
+                    <div className="w-11 h-6 bg-gray-600 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-[#333e48]"></div>
+                  </label>
                 </div>
-                <label className="relative inline-flex items-center cursor-pointer">
-                  <input type="checkbox" className="sr-only peer" />
-                  <div className="w-11 h-6 bg-gray-600 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-[#333e48]"></div>
-                </label>
               </div>
-            </div>
-          </section>
+            </section>
 
-          {/* Display */}
-          <section className="bg-dark-100 rounded-xl p-6">
-            <h2 className="text-xl font-semibold text-white mb-4">Display</h2>
-            <div className="space-y-4">
-              <div className="flex items-center justify-between">
-                <div>
-                  <h3 className="text-white font-medium">Dark Mode</h3>
-                  <p className="text-sm text-gray-400">Toggle dark mode theme</p>
+            {/* Display */}
+            <section className="bg-dark-100 rounded-xl p-6">
+              <h2 className="text-xl font-semibold text-white mb-4">Display</h2>
+              <div className="space-y-4">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <h3 className="text-white font-medium">Dark Mode</h3>
+                    <p className="text-sm text-gray-400">
+                      Toggle dark mode theme
+                    </p>
+                  </div>
+                  <label className="relative inline-flex items-center cursor-pointer">
+                    <input
+                      type="checkbox"
+                      className="sr-only peer"
+                      defaultChecked
+                    />
+                    <div className="w-11 h-6 bg-gray-600 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-[#333e48]"></div>
+                  </label>
                 </div>
-                <label className="relative inline-flex items-center cursor-pointer">
-                  <input type="checkbox" className="sr-only peer" defaultChecked />
-                  <div className="w-11 h-6 bg-gray-600 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-[#333e48]"></div>
-                </label>
+                <div>
+                  <h3 className="text-white font-medium mb-2">Text Size</h3>
+                  <select
+                    defaultValue="Medium"
+                    className="w-full bg-dark-200 text-white rounded-lg px-4 py-2 focus:outline-none focus:ring-2 focus:ring-[#333e48]"
+                  >
+                    <option>Small</option>
+                    <option>Medium</option>
+                    <option>Large</option>
+                  </select>
+                </div>
               </div>
-              <div>
-                <h3 className="text-white font-medium mb-2">Text Size</h3>
-                <select 
-                  defaultValue="Medium"
-                  className="w-full bg-dark-200 text-white rounded-lg px-4 py-2 focus:outline-none focus:ring-2 focus:ring-[#333e48]"
-                >
-                  <option>Small</option>
-                  <option>Medium</option>
-                  <option>Large</option>
-                </select>
-              </div>
-            </div>
-          </section>
+            </section>
 
-          {/* Privacy */}
-          <section className="bg-dark-100 rounded-xl p-6">
-            <h2 className="text-xl font-semibold text-white mb-4">Privacy</h2>
-            <div className="space-y-4">
-              <div className="flex items-center justify-between">
-                <div>
-                  <h3 className="text-white font-medium">Profile Visibility</h3>
-                  <p className="text-sm text-gray-400">Make your profile visible to others</p>
+            {/* Privacy */}
+            <section className="bg-dark-100 rounded-xl p-6">
+              <h2 className="text-xl font-semibold text-white mb-4">Privacy</h2>
+              <div className="space-y-4">
+                <div className="flex items-center justify-between">
+                  <div>
+                    <h3 className="text-white font-medium">
+                      Profile Visibility
+                    </h3>
+                    <p className="text-sm text-gray-400">
+                      Make your profile visible to others
+                    </p>
+                  </div>
+                  <label className="relative inline-flex items-center cursor-pointer">
+                    <input
+                      type="checkbox"
+                      className="sr-only peer"
+                      defaultChecked
+                    />
+                    <div className="w-11 h-6 bg-gray-600 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-[#333e48]"></div>
+                  </label>
                 </div>
-                <label className="relative inline-flex items-center cursor-pointer">
-                  <input type="checkbox" className="sr-only peer" defaultChecked />
-                  <div className="w-11 h-6 bg-gray-600 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-[#333e48]"></div>
-                </label>
-              </div>
-              <div className="flex items-center justify-between">
-                <div>
-                  <h3 className="text-white font-medium">Activity Status</h3>
-                  <p className="text-sm text-gray-400">Show when you're online</p>
+                <div className="flex items-center justify-between">
+                  <div>
+                    <h3 className="text-white font-medium">Activity Status</h3>
+                    <p className="text-sm text-gray-400">
+                      Show when you're online
+                    </p>
+                  </div>
+                  <label className="relative inline-flex items-center cursor-pointer">
+                    <input type="checkbox" className="sr-only peer" />
+                    <div className="w-11 h-6 bg-gray-600 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-[#333e48]"></div>
+                  </label>
                 </div>
-                <label className="relative inline-flex items-center cursor-pointer">
-                  <input type="checkbox" className="sr-only peer" />
-                  <div className="w-11 h-6 bg-gray-600 rounded-full peer peer-checked:after:translate-x-full peer-checked:after:border-white after:content-[''] after:absolute after:top-0.5 after:left-[2px] after:bg-white after:border-gray-300 after:border after:rounded-full after:h-5 after:w-5 after:transition-all peer-checked:bg-[#333e48]"></div>
-                </label>
               </div>
-            </div>
-          </section>
+            </section>
 
-          {/* Account */}
-          <section className="bg-dark-100 rounded-xl p-6">
-            <h2 className="text-xl font-semibold text-white mb-4">Account</h2>
-            <div className="space-y-4">
-              <button className="w-full py-2 px-4 bg-[#333e48] text-white rounded-lg hover:bg-[#4a5761] transition-colors">
-                Change Password
-              </button>
-              <button className="w-full py-2 px-4 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors">
-                Delete Account
-              </button>
-            </div>
-          </section>
+            {/* Account */}
+            <section className="bg-dark-100 rounded-xl p-6">
+              <h2 className="text-xl font-semibold text-white mb-4">Account</h2>
+              <div className="space-y-4">
+                <button className="w-full py-2 px-4 bg-[#333e48] text-white rounded-lg hover:bg-[#4a5761] transition-colors">
+                  Change Password
+                </button>
+                <button className="w-full py-2 px-4 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-colors">
+                  Delete Account
+                </button>
+              </div>
+            </section>
+          </div>
         </div>
       </div>
     </div>
-  )
+  );
 }

--- a/src/pages/Stats.tsx
+++ b/src/pages/Stats.tsx
@@ -1,220 +1,259 @@
-import React, { useState } from 'react'
-import { Button } from '../components/ui/Button'
-import { Card } from '../components/ui/Card'
-import { Grid } from '../components/layout/Grid'
-import { StatCard } from '../components/ui/StatCard'
+import React, { useState } from "react";
+import { Button } from "../components/ui/Button";
+import { Card } from "../components/ui/Card";
+import { Grid } from "../components/layout/Grid";
+import { StatCard } from "../components/ui/StatCard";
 
 export default function Stats() {
-  const [selectedPeriod, setSelectedPeriod] = useState('30')
-  const [showAchievementDetails, setShowAchievementDetails] = useState(false)
-  const [_selectedAchievement, setSelectedAchievement] = useState(null)
-  const [showPeriodDropdown, setShowPeriodDropdown] = useState(false)
+  const [selectedPeriod, setSelectedPeriod] = useState("30");
+  const [showAchievementDetails, setShowAchievementDetails] = useState(false);
+  const [_selectedAchievement, setSelectedAchievement] = useState(null);
+  const [showPeriodDropdown, setShowPeriodDropdown] = useState(false);
 
   const stats = {
     titlesPlayed: 24,
     averageScore: 714,
     bestScore: 1075,
     hoursPlayed: 7,
-  }
+  };
 
   const recentScores = [
-    { date: 'Dec 15, 2024', score: 82, course: 'Lodge2A Main Course' },
-    { date: 'Dec 10, 2024', score: 85, course: 'Lodge2A Main Course' },
-    { date: 'Dec 5, 2024', score: 79, course: 'Lodge2A Main Course' },
-    { date: 'Nov 30, 2024', score: 81, course: 'Lodge2A Main Course' },
-  ]
+    { date: "Dec 15, 2024", score: 82, course: "Lodge2A Main Course" },
+    { date: "Dec 10, 2024", score: 85, course: "Lodge2A Main Course" },
+    { date: "Dec 5, 2024", score: 79, course: "Lodge2A Main Course" },
+    { date: "Nov 30, 2024", score: 81, course: "Lodge2A Main Course" },
+  ];
 
   const achievements = [
-    { id: 1, name: 'Achievement 1', description: 'Description 1' },
-    { id: 2, name: 'Achievement 2', description: 'Description 2' },
-    { id: 3, name: 'Achievement 3', description: 'Description 3' },
-  ]
+    { id: 1, name: "Achievement 1", description: "Description 1" },
+    { id: 2, name: "Achievement 2", description: "Description 2" },
+    { id: 3, name: "Achievement 3", description: "Description 3" },
+  ];
 
   const handlePeriodChange = (period: string) => {
-    setSelectedPeriod(period)
-  }
+    setSelectedPeriod(period);
+  };
 
   const handleAchievementClick = (achievement: any) => {
-    setSelectedAchievement(achievement)
-    setShowAchievementDetails(true)
-  }
+    setSelectedAchievement(achievement);
+    setShowAchievementDetails(true);
+  };
 
   return (
-    <div className="container mx-auto px-4 py-6 md:py-8">
-      <div className="mb-6 md:mb-8">
-        <h1 className="text-2xl md:text-3xl font-bold text-white mb-2">Your Stats</h1>
-        <p className="text-gray-400">Track your performance and progress</p>
-      </div>
+    <div className="min-h-screen pb-20 tablet:pb-0">
+      <div className="container mx-auto px-4 py-6 md:py-8">
+        <div className="mb-6 md:mb-8">
+          <h1 className="text-2xl md:text-3xl font-bold text-white mb-2">
+            Your Stats
+          </h1>
+          <p className="text-gray-400">Track your performance and progress</p>
+        </div>
 
-      {/* Stats Overview */}
-      <Grid cols={1} mdCols={2} lgCols={4} gap={6} className="mb-6 md:mb-8">
-        <StatCard
-          title="Titles Played"
-          value={stats.titlesPlayed}
-          icon={
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
-              />
-            </svg>
-          }
-        />
-        <StatCard
-          title="Average Score"
-          value={stats.averageScore.toLocaleString()}
-          icon={
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6"
-              />
-            </svg>
-          }
-        />
-        <StatCard
-          title="Best Score"
-          value={stats.bestScore.toLocaleString()}
-          icon={
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z"
-              />
-            </svg>
-          }
-        />
-        <StatCard
-          title="Hours Played"
-          value={stats.hoursPlayed}
-          icon={
-            <svg className="w-5 h-5" fill="none" stroke="currentColor" viewBox="0 0 24 24">
-              <path
-                strokeLinecap="round"
-                strokeLinejoin="round"
-                strokeWidth={2}
-                d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
-              />
-            </svg>
-          }
-        />
-      </Grid>
-
-      {/* Score History */}
-      <Grid cols={2} gap={6} className="grid-cols-1 lg:grid-cols-2">
-        {/* Recent Scores */}
-        <Card>
-          <div className="flex justify-between items-center mb-4">
-            <h2 className="text-lg md:text-xl font-semibold text-white">Recent Scores</h2>
-            <Button variant="secondary" className="flex-1 sm:flex-none">
-              View All
-            </Button>
-          </div>
-          <div className="space-y-4">
-            {recentScores.map((score, index) => (
-              <div
-                key={index}
-                className="flex items-center justify-between p-3 bg-dark-200 rounded-lg"
+        {/* Stats Overview */}
+        <Grid cols={1} mdCols={2} lgCols={4} gap={6} className="mb-6 md:mb-8">
+          <StatCard
+            title="Titles Played"
+            value={stats.titlesPlayed}
+            icon={
+              <svg
+                className="w-5 h-5"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
               >
-                <div className="flex items-center space-x-3">
-                  <div className="w-10 h-10 rounded-full bg-[#2d3339] flex items-center justify-center flex-shrink-0">
-                    <span className="text-white font-bold">{score.score}</span>
-                  </div>
-                  <div>
-                    <p className="text-sm md:text-base text-white font-medium">{score.course}</p>
-                    <p className="text-xs md:text-sm text-gray-400">{score.date}</p>
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M9 12l2 2 4-4m6 2a9 9 0 11-18 0 9 9 0 0118 0z"
+                />
+              </svg>
+            }
+          />
+          <StatCard
+            title="Average Score"
+            value={stats.averageScore.toLocaleString()}
+            icon={
+              <svg
+                className="w-5 h-5"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M13 7h8m0 0v8m0-8l-8 8-4-4-6 6"
+                />
+              </svg>
+            }
+          />
+          <StatCard
+            title="Best Score"
+            value={stats.bestScore.toLocaleString()}
+            icon={
+              <svg
+                className="w-5 h-5"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M5 3v4M3 5h4M6 17v4m-2-2h4m5-16l2.286 6.857L21 12l-5.714 2.143L13 21l-2.286-6.857L5 12l5.714-2.143L13 3z"
+                />
+              </svg>
+            }
+          />
+          <StatCard
+            title="Hours Played"
+            value={stats.hoursPlayed}
+            icon={
+              <svg
+                className="w-5 h-5"
+                fill="none"
+                stroke="currentColor"
+                viewBox="0 0 24 24"
+              >
+                <path
+                  strokeLinecap="round"
+                  strokeLinejoin="round"
+                  strokeWidth={2}
+                  d="M12 8v4l3 3m6-3a9 9 0 11-18 0 9 9 0 0118 0z"
+                />
+              </svg>
+            }
+          />
+        </Grid>
+
+        {/* Score History */}
+        <Grid cols={2} gap={6} className="grid-cols-1 lg:grid-cols-2">
+          {/* Recent Scores */}
+          <Card>
+            <div className="flex justify-between items-center mb-4">
+              <h2 className="text-lg md:text-xl font-semibold text-white">
+                Recent Scores
+              </h2>
+              <Button variant="secondary" className="flex-1 sm:flex-none">
+                View All
+              </Button>
+            </div>
+            <div className="space-y-4">
+              {recentScores.map((score, index) => (
+                <div
+                  key={index}
+                  className="flex items-center justify-between p-3 bg-dark-200 rounded-lg"
+                >
+                  <div className="flex items-center space-x-3">
+                    <div className="w-10 h-10 rounded-full bg-[#2d3339] flex items-center justify-center flex-shrink-0">
+                      <span className="text-white font-bold">
+                        {score.score}
+                      </span>
+                    </div>
+                    <div>
+                      <p className="text-sm md:text-base text-white font-medium">
+                        {score.course}
+                      </p>
+                      <p className="text-xs md:text-sm text-gray-400">
+                        {score.date}
+                      </p>
+                    </div>
                   </div>
                 </div>
+              ))}
+            </div>
+          </Card>
+
+          {/* Performance Chart */}
+          <Card>
+            <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between mb-4 space-y-3 sm:space-y-0">
+              <h2 className="text-lg md:text-xl font-semibold text-white">
+                Score Trends
+              </h2>
+              <div className="flex w-full sm:w-auto space-x-2">
+                <Button variant="primary" className="flex-1 sm:flex-none">
+                  Week
+                </Button>
+                <Button variant="secondary" className="flex-1 sm:flex-none">
+                  Month
+                </Button>
+                <Button variant="secondary" className="flex-1 sm:flex-none">
+                  Year
+                </Button>
+              </div>
+            </div>
+            <div className="h-64 flex items-center justify-center text-gray-400">
+              Chart Component Here
+            </div>
+          </Card>
+        </Grid>
+
+        {/* Score Distribution */}
+        <Card className="mb-6 md:mb-8">
+          <div className="flex justify-between items-center mb-4">
+            <h2 className="text-xl font-semibold text-white">
+              Score Distribution
+            </h2>
+            <div className="relative">
+              <Button
+                variant="secondary"
+                onClick={() => setShowPeriodDropdown(!showPeriodDropdown)}
+              >
+                {`Last ${selectedPeriod} Days`}
+              </Button>
+              {showPeriodDropdown && (
+                <div className="absolute right-0 mt-2 w-48 bg-gray-800 rounded-lg shadow-lg z-10">
+                  {["7", "30", "90", "all"].map((period) => (
+                    <button
+                      key={period}
+                      className="block w-full px-4 py-2 text-left text-white hover:bg-gray-700"
+                      onClick={() => handlePeriodChange(period)}
+                    >
+                      {period === "all" ? "All Time" : `Last ${period} Days`}
+                    </button>
+                  ))}
+                </div>
+              )}
+            </div>
+          </div>
+          <div
+            data-testid="score-distribution-chart"
+            data-period={selectedPeriod}
+          >
+            {/* Chart implementation */}
+          </div>
+        </Card>
+
+        {/* Achievements section */}
+        <div className="mb-6 md:mb-8">
+          <div className="flex justify-between items-center mb-4">
+            <h2 className="text-xl font-semibold text-white">Achievements</h2>
+            <Button variant="link">View All</Button>
+          </div>
+          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+            {achievements.map((achievement, index) => (
+              <div
+                key={index}
+                data-testid="achievement-card"
+                className="cursor-pointer"
+                onClick={() => handleAchievementClick(achievement)}
+              >
+                {/* Achievement card content */}
               </div>
             ))}
           </div>
-        </Card>
+        </div>
 
-        {/* Performance Chart */}
-        <Card>
-          <div className="flex flex-col sm:flex-row items-start sm:items-center justify-between mb-4 space-y-3 sm:space-y-0">
-            <h2 className="text-lg md:text-xl font-semibold text-white">Score Trends</h2>
-            <div className="flex w-full sm:w-auto space-x-2">
-              <Button variant="primary" className="flex-1 sm:flex-none">
-                Week
-              </Button>
-              <Button variant="secondary" className="flex-1 sm:flex-none">
-                Month
-              </Button>
-              <Button variant="secondary" className="flex-1 sm:flex-none">
-                Year
-              </Button>
-            </div>
+        {/* Achievement details modal */}
+        {showAchievementDetails && (
+          <div data-testid="achievement-details">
+            {/* Achievement details content */}
           </div>
-          <div className="h-64 flex items-center justify-center text-gray-400">
-            Chart Component Here
-          </div>
-        </Card>
-      </Grid>
-
-      {/* Score Distribution */}
-      <Card className="mb-6 md:mb-8">
-        <div className="flex justify-between items-center mb-4">
-          <h2 className="text-xl font-semibold text-white">Score Distribution</h2>
-          <div className="relative">
-            <Button
-              variant="secondary"
-              onClick={() => setShowPeriodDropdown(!showPeriodDropdown)}
-            >
-              {`Last ${selectedPeriod} Days`}
-            </Button>
-            {showPeriodDropdown && (
-              <div className="absolute right-0 mt-2 w-48 bg-gray-800 rounded-lg shadow-lg z-10">
-                {['7', '30', '90', 'all'].map((period) => (
-                  <button
-                    key={period}
-                    className="block w-full px-4 py-2 text-left text-white hover:bg-gray-700"
-                    onClick={() => handlePeriodChange(period)}
-                  >
-                    {period === 'all' ? 'All Time' : `Last ${period} Days`}
-                  </button>
-                ))}
-              </div>
-            )}
-          </div>
-        </div>
-        <div data-testid="score-distribution-chart" data-period={selectedPeriod}>
-          {/* Chart implementation */}
-        </div>
-      </Card>
-
-      {/* Achievements section */}
-      <div className="mb-6 md:mb-8">
-        <div className="flex justify-between items-center mb-4">
-          <h2 className="text-xl font-semibold text-white">Achievements</h2>
-          <Button variant="link">View All</Button>
-        </div>
-        <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-          {achievements.map((achievement, index) => (
-            <div
-              key={index}
-              data-testid="achievement-card"
-              className="cursor-pointer"
-              onClick={() => handleAchievementClick(achievement)}
-            >
-              {/* Achievement card content */}
-            </div>
-          ))}
-        </div>
+        )}
       </div>
-
-      {/* Achievement details modal */}
-      {showAchievementDetails && (
-        <div data-testid="achievement-details">
-          {/* Achievement details content */}
-        </div>
-      )}
     </div>
-  )
+  );
 }


### PR DESCRIPTION
Changes:
- Add mobile-only bottom padding to all pages with FloatingMenu
- Padding removes on tablet and larger screens
- Prevents content from being obscured by FloatingMenu
- Applied to Dashboard, Reservations, Events, Stats, ProShop, and Settings pages